### PR TITLE
feat: include comments from tagged template literals by default

### DIFF
--- a/packages/parse-print/src/__tests__/index.test.ts
+++ b/packages/parse-print/src/__tests__/index.test.ts
@@ -285,3 +285,42 @@ test('scope regression', () => {
 
   expect(print()).toEqual(['console.log(42);'].join('\n'));
 });
+
+test('template with comments', () => {
+  const code = ['const value = 42, negative = -42;'].join('\n');
+
+  const {root, print, template} = parse(code, {sourceType: 'module'});
+
+  for (const declaration of root.find(filters.VariableDeclaration)) {
+    declaration.insertAfter(template.statement`
+      // log the values
+      console.log(${declaration.node.declarations.map((d) => d.id)})
+    `);
+  }
+
+  expect(print()).toEqual(
+    [
+      'const value = 42, negative = -42;',
+      '// log the values',
+      'console.log(value, negative);',
+    ].join('\n'),
+  );
+});
+test('template without comments', () => {
+  const code = ['const value = 42, negative = -42;'].join('\n');
+
+  const {root, print, template} = parse(code, {sourceType: 'module'});
+
+  for (const declaration of root.find(filters.VariableDeclaration)) {
+    declaration.insertAfter(template.statement.withoutComments`
+      // log the values
+      console.log(${declaration.node.declarations.map((d) => d.id)})
+    `);
+  }
+
+  expect(print()).toEqual(
+    ['const value = 42, negative = -42;', 'console.log(value, negative);'].join(
+      '\n',
+    ),
+  );
+});

--- a/packages/parse-print/src/template.ts
+++ b/packages/parse-print/src/template.ts
@@ -1,0 +1,78 @@
+import babelTemplate, {
+  TemplateBuilder,
+  TemplateBuilderOptions,
+} from '@babel/template';
+import {ParserOptions} from '@babel/parser';
+import {Statement, Expression} from '@babel/types';
+
+export interface TemplateHelpers {
+  statement: ((tpl: TemplateStringsArray, ...args: unknown[]) => Statement) & {
+    withoutComments: (
+      tpl: TemplateStringsArray,
+      ...args: unknown[]
+    ) => Statement;
+  };
+  statements: ((
+    tpl: TemplateStringsArray,
+    ...args: unknown[]
+  ) => Statement[]) & {
+    withoutComments: (
+      tpl: TemplateStringsArray,
+      ...args: unknown[]
+    ) => Statement[];
+  };
+  expression: ((
+    tpl: TemplateStringsArray,
+    ...args: unknown[]
+  ) => Expression) & {
+    withoutComments: (
+      tpl: TemplateStringsArray,
+      ...args: unknown[]
+    ) => Expression;
+  };
+}
+export default function template(
+  opts: Omit<ParserOptions, 'ranges'> = {},
+): TemplateHelpers {
+  return {
+    statement: syntacticTemplateWithCommentsHelper(
+      babelTemplate.statement({...opts, ranges: false}),
+    ),
+    statements: syntacticTemplateWithCommentsHelper(
+      babelTemplate.statements({...opts, ranges: false}),
+    ),
+    expression: syntacticTemplateWithCommentsHelper(
+      babelTemplate.expression({...opts, ranges: false}),
+    ),
+  };
+}
+function syntacticTemplateWithCommentsHelper<T>(builder: TemplateBuilder<T>) {
+  return Object.assign(syntacticTemplate(builder({preserveComments: true})), {
+    withoutComments: syntacticTemplate(builder({preserveComments: false})),
+  });
+}
+function syntacticTemplate<T>(builder: TemplateBuilder<T>) {
+  const builder2 = builder({
+    syntacticPlaceholders: true,
+  } as TemplateBuilderOptions);
+  const templateFnCache = new WeakMap<
+    TemplateStringsArray,
+    (arg: {[index: string]: unknown}) => T
+  >();
+  return (tpl: TemplateStringsArray, ...args: unknown[]) => {
+    let fn = templateFnCache.get(tpl);
+    if (!fn) {
+      fn = builder2(
+        tpl
+          .map((str, i) => (i === 0 ? str : `%%placeholder${i - 1}%%${str}`))
+          .join(''),
+      );
+      templateFnCache.set(tpl, fn);
+    }
+    const argsObj: {[index: string]: unknown} = {};
+    for (let i = 0; i < args.length; i++) {
+      argsObj[`placeholder${i}`] = args[i];
+    }
+    return fn(argsObj);
+  };
+}


### PR DESCRIPTION
You can append `.withoutComments` to the template prefix if you want the old behaviour.