### PR TITLE
Prevent exception on a class expression without an id

### DIFF
--- a/packages/babel-scope/src/index.ts
+++ b/packages/babel-scope/src/index.ts
@@ -184,9 +184,12 @@ const firstPass = walk<Context>({
     }
   },
   ClassDeclaration(node, state, parents) {
+    if (!node.id) {
+      return;
+    }
     for (let i = parents.length - 2; i >= 0; i--) {
       const parent = parents[i];
-      if (isScope(parent) && node.id) {
+      if (isScope(parent)) {
         setLocal(state, parent, node.id, parents.slice().reverse().slice(1));
         return;
       }

--- a/packages/babel-scope/src/index.ts
+++ b/packages/babel-scope/src/index.ts
@@ -186,7 +186,7 @@ const firstPass = walk<Context>({
   ClassDeclaration(node, state, parents) {
     for (let i = parents.length - 2; i >= 0; i--) {
       const parent = parents[i];
-      if (isScope(parent)) {
+      if (isScope(parent) && node.id) {
         setLocal(state, parent, node.id, parents.slice().reverse().slice(1));
         return;
       }


### PR DESCRIPTION
```
export default class {};
```
the class does not have an id and codemod tools throws.